### PR TITLE
Add Basic Setup and Install Script for Universal Installer

### DIFF
--- a/BasicSetup.ps1
+++ b/BasicSetup.ps1
@@ -1,0 +1,81 @@
+function IsProcessElevated {
+    return (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+        [Security.Principal.WindowsBuiltInRole] "Administrator")
+    );
+}
+
+function PromptActionConfirmation {
+    param ([string]$PromptMsg, [ConsoleColor]$Color);
+    if ($Color -eq $null) {
+        $Color = "Green";
+    }
+    Write-Host $PromptMsg -ForegroundColor $Color;
+    $UserInput = Read-Host -Prompt "Enter Y/N to proceed/skip: ";
+    return $UserInput -eq "Y";
+}
+
+if (-NOT (IsProcessElevated)) {
+    Write-Host "This script requires administrator permissions. It will now terminate." -ForegroundColor Red;
+    Break;
+}
+
+Write-Host (
+    "---- BASIC SETUP ----",
+    "This script is a univeral script that should be executed when the machine is first initialized."
+    ) -Separator "`r`n";
+
+if (-NOT (PromptActionConfirmation -PromptMsg "This script requires administrator permissions and makes system changes." -Color Red)) {
+    Break;
+}
+
+if (PromptActionConfirmation -PromptMsg "Install Powershell 7") {
+    iex "& { $(irm https://aka.ms/install-powershell.ps1)} -UseMSI -Quiet";
+}
+
+if (PromptActionConfirmation -PromptMsg "Update Windows") {
+    if (-NOT (Get-Module -ListAvailable -Name PSWindowsUpdate)) {
+        Install-Module PSWindowsUpdate;
+    }
+    Get-WindowsUpdate;
+    Install-WindowsUpdate;
+}
+
+if (PromptActionConfirmation -PromptMsg "Enable Optional Features. REQUIRED FOR WSL2 STEPS (includes WSL)") {
+    Disable-WindowsOptionalFeature -Online -NoRestart -FeatureName MediaPlayback;
+    Disable-WindowsOptionalFeature -Online -NoRestart -FeatureName MicrosoftWindowsPowerShellV2Root;
+    Enable-WindowsOptionalFeature -Online -All -NoRestart -FeatureName VirtualMachinePlatform;
+        Enable-WindowsOptionalFeature -Online -All -NoRestart -FeatureName Microsoft-Windows-Subsystem-Linux;
+    if (PromptActionConfirmation -PromptMsg "Proceed with WSL Step 1 and 2 Afterwards.." -Color Red) {
+        Restart-Computer
+    }
+}
+
+if (PromptActionConfirmation -PromptMsg "WSL2") {
+    $tmp = "$env:TEMP\wsl_update_x64.msi";
+    Invoke-WebRequest -Uri "https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi" -OutFile $tmp;
+    msiexec /i $tmp /passive /norestart;
+    del $tmp;
+    wsl --set-default-version 2
+}
+
+
+if (PromptActionConfirmation -PromptMsg "Install Core Programs! REQUIRES WINGET." -Color Red) {
+    winget install Microsoft.PowerToys;
+    winget install Microsoft.WindowsTerminal;
+    winget install Git.Git;
+    winget install Microsoft.EdgeDev;
+    winget install 7Zip.7Zip;
+    winget install Piriform.CCleaner;
+    winget install TeamViewer.TeamViewer;
+}
+
+
+if (PromptActionConfirmation -PromptMsg "Install Chocolatey") {
+    Set-ExecutionPolicy Bypass -Scope Process -Force;
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+    iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+}
+
+if (PromptActionConfirmation -PromptMsg "Restart is highly reccomended. Can restart?" -Color Red) {
+    Restart-Computer
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+1. Uninstall unwanted bloatware via Control Panel and Windows 10 Settings App (and optional features).
+2. Upgrade Microsoft Edge.
+3. Setup Windows Insider to Release Candidates.
+4. Run BasicSetup PowerShell Script ONLY STEPS 1 and 2.
+5. Install App Installer from MS Store (and test `winget`).
+6. Run BasicSetup PowerShell NOT 1 ALL OTHERS.
+7. Run UniversalPrograms installation.
+8. Install Ubuntu 20.04 LTS via MS Store.

--- a/UniversalPrograms.ps1
+++ b/UniversalPrograms.ps1
@@ -1,0 +1,50 @@
+function IsProcessElevated {
+    return (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+        [Security.Principal.WindowsBuiltInRole] "Administrator")
+    );
+}
+
+function PromptActionConfirmation {
+    param ([string]$PromptMsg, [ConsoleColor]$Color);
+    if ($Color -eq $null) {
+        $Color = "Green";
+    }
+    Write-Host $PromptMsg -ForegroundColor $Color;
+    $UserInput = Read-Host -Prompt "Enter Y/N: ";
+    return $UserInput -eq "Y";
+}
+
+if (-NOT (IsProcessElevated)) {
+    Write-Host "This script requires administrator permissions. It will now terminate." -ForegroundColor Red;
+    Break;
+}
+
+Write-Host (
+    "---- UNIVERSAL PROGRAMS ----",
+    "This script installs programs for all installations via Winget and Chocolatey. Requires Winget (preferred) and Chocolatey from BasicSetup."
+    ) -Separator "`r`n";
+
+if (-NOT (PromptActionConfirmation -PromptMsg "CONFIRM: Once you accept, this utility will install many 'universal' programs to your system." -Color Red)) {
+    Break;
+}
+
+$Desktop = PromptActionConfirmation -PromptMsg "Is this a desktop PC?";
+
+winget install Microsoft.Edge;
+winget install Videolan.Vlc;
+winget install Canonical.Ubuntu;
+winget install Python.Python;
+winget install VSCodium.VSCodium;
+winget install Spotify.Spotify;
+winget install Discord.Discord;
+winget install Microsoft.Teams;
+winget install Zoom.Zoom;
+winget install GIMP.GIMP;
+winget install Zotero.Zotero;
+winget install Audacity.Audacity;
+winget install WhatsApp.WhatsApp;
+winget install Malwarebytes.Malwarebytes;
+if ($Desktop) {
+    winget install Lexikos.AutoHotKey;
+    winget install calibre.calibre;
+}


### PR DESCRIPTION
This pull request adds functionality for setting up brand new devices.

It does not prepare a development environment, but instead, setups up the computer basics (and software management basics) useful for all installations by this procedure. It also installs prerequisites for future software installations such as winget and chocolatey.

Additionally, it installs all the basic software required.